### PR TITLE
feat: photo-album-detail #27

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,9 @@ dependencies {
 
     implementation("com.kakao.maps.open:android:2.12.8")
 
+    // flexbox
+    implementation("com.google.android.flexbox:flexbox:3.0.0")
+
     // Coil
     implementation("io.coil-kt:coil-compose:2.6.0")
     implementation("io.coil-kt.coil3:coil-compose:3.1.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,11 +2,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <!-- 갤러리-->
     <!-- Android 13 이상 -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
-
-    <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Android 13 미만 저장-->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"/>
 
     <application
         android:name=".MyApp"
@@ -41,6 +44,8 @@
             android:exported="false"/>
 
         <activity android:name=".presentation.main.photo_album.PhotoAlbumActivity"
+            android:exported="false"/>
+        <activity android:name=".presentation.main.photo_album.detail.PhotoAlbumDetailActivity"
             android:exported="false"/>
     </application>
 

--- a/app/src/main/java/com/hyosimroad/hamkkae/domain/model/Album.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/domain/model/Album.kt
@@ -6,6 +6,15 @@ data class Album (
     val startDate:String,
     val endDate:String,
     val place:String,
-    val photos:Int,
+    val photos:List<Photo>,
     val keywords:List<String>
-)
+){
+    data class Photo(
+        val id:Int,
+        val url:String,
+        val place:String,
+        val description:String,
+        val time:String,
+        val keywords:List<String>
+    )
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/adapter/trip_record/TripRecordAdapter.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/adapter/trip_record/TripRecordAdapter.kt
@@ -31,7 +31,7 @@ class TripRecordAdapter : ListAdapter<TripRecord, TripRecordAdapter.TripRecordVi
         fun bind(tripRecord: TripRecord) {
             with(binding){
                 tvTitle.text = tripRecord.content
-                tvDate.text = binding.root.context.getString(R.string.main_trip_record_date, tripRecord.startDate, tripRecord.endDate)
+                tvDate.text = binding.root.context.getString(R.string.main_trip_record_during, tripRecord.startDate, tripRecord.endDate)
                 tvState.text = tripRecord.state
             }
         }

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/PhotoAlbumActivity.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/PhotoAlbumActivity.kt
@@ -10,10 +10,11 @@ import androidx.appcompat.app.AppCompatActivity
 import com.hyosimroad.hamkkae.R
 import com.hyosimroad.hamkkae.databinding.ActivityPhotoAlbumBinding
 import com.hyosimroad.hamkkae.presentation.main.MainViewModel
+import com.hyosimroad.hamkkae.presentation.main.photo_album.detail.PhotoAlbumDetailActivity
 import timber.log.Timber
 import kotlin.getValue
 
-class PhotoAlbumActivity: AppCompatActivity() {
+class PhotoAlbumActivity : AppCompatActivity() {
     private lateinit var binding: ActivityPhotoAlbumBinding
     private val photoAlbumViewModel: PhotoAlbumViewModel by viewModels()
 
@@ -29,14 +30,14 @@ class PhotoAlbumActivity: AppCompatActivity() {
     }
 
     private fun setting() {
-       setStatistics()
+        setStatistics()
     }
 
-    private fun setStatistics(){
-        with(binding){
-            tvTotalAlbumsCount.text="3"
-            tvTotalPhotosCount.text="34"
-            tvTotalDaysCount.text="3"
+    private fun setStatistics() {
+        with(binding) {
+            tvTotalAlbumsCount.text = "3"
+            tvTotalPhotosCount.text = "34"
+            tvTotalDaysCount.text = "3"
 
             rvAlbums.visibility = View.VISIBLE
         }
@@ -44,9 +45,15 @@ class PhotoAlbumActivity: AppCompatActivity() {
         setAlbums()
     }
 
-    private fun setAlbums(){
-        val photoAlbumAdapter = PhotoAlbumAdapter()
+    private fun setAlbums() {
+        val photoAlbumAdapter = PhotoAlbumAdapter(clickAlbum = { id -> navigateToDetail(id) })
         binding.rvAlbums.adapter = photoAlbumAdapter
         photoAlbumAdapter.submitList(photoAlbumViewModel.albumList)
+    }
+
+    private fun navigateToDetail(id:Int) {
+        val intent = Intent(this, PhotoAlbumDetailActivity::class.java)
+        intent.putExtra("albumId", id)
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/PhotoAlbumAdapter.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/PhotoAlbumAdapter.kt
@@ -8,12 +8,15 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import coil.load
 import com.hyosimroad.hamkkae.R
 import com.hyosimroad.hamkkae.databinding.ItemPhotoAlbumBinding
 import com.hyosimroad.hamkkae.domain.model.Album
 import timber.log.Timber
 
-class PhotoAlbumAdapter: ListAdapter<Album, PhotoAlbumAdapter.PhotoAlbumViewHolder>(PhotoAlbumDiffCallback) {
+class PhotoAlbumAdapter(
+    private val clickAlbum:(Int) -> Unit
+): ListAdapter<Album, PhotoAlbumAdapter.PhotoAlbumViewHolder>(PhotoAlbumDiffCallback) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
@@ -47,15 +50,17 @@ class PhotoAlbumAdapter: ListAdapter<Album, PhotoAlbumAdapter.PhotoAlbumViewHold
 
                 tvTripName.text = album.name
                 tvDuring.text = binding.root.context.getString(
-                    R.string.main_trip_record_date,
+                    R.string.main_trip_record_during,
                     album.startDate,
                     album.endDate
                 )
                 tvInfo.text = binding.root.context.getString(
                     R.string.photo_album_info_format,
                     album.place,
-                    album.photos
+                    album.photos.size
                 )
+
+                ivImage.load(album.photos[0].url)
 
                 val textAdapter = TextAdapter()
                 val layoutManager =
@@ -71,6 +76,10 @@ class PhotoAlbumAdapter: ListAdapter<Album, PhotoAlbumAdapter.PhotoAlbumViewHold
                 }
                 Timber.d("modifylist: $modifyList")
                 textAdapter.submitList(modifyList)
+
+                clAlbum.setOnClickListener {
+                    clickAlbum(album.id)
+                }
             }
         }
 

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/PhotoAlbumViewModel.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/PhotoAlbumViewModel.kt
@@ -2,11 +2,101 @@ package com.hyosimroad.hamkkae.presentation.main.photo_album
 
 import androidx.lifecycle.ViewModel
 import com.hyosimroad.hamkkae.domain.model.Album
+import com.hyosimroad.hamkkae.domain.model.Album.Photo
 
-class PhotoAlbumViewModel: ViewModel() {
+class PhotoAlbumViewModel : ViewModel() {
     val albumList = listOf(
-        Album(1, "경주 역사문화 코스", "2025.06.14", "2025.06.17", "경주시", 3, listOf("감동", "경건함", "가족애", "전통미")),
-        Album(2, "부산 해변 드라이브", "2025.07.01", "2025.07.03", "부산시", 2, listOf("힐링", "바다", "낭만", "드라이브")),
-        Album(3, "제주도 한라산 등반", "2025.08.10", "2025.08.12", "제주시", 1, listOf("도전", "자연", "성취감", "풍경"))
+        Album(
+            1, "경주 역사문화 코스", "2025.06.14", "2025.06.17", "경주시", listOf(
+                Photo(
+                    1,
+                    "https://www.gyeongju.go.kr/design/tour2019/img/sub/themaImg3.jpg",
+                    "첨성대",
+                    "밤하늘의 별을 관측하던 신라시대 건축물",
+                    "2025.06.14 19:00",
+                    listOf("야경", "별", "신라", "역사유적")
+                ),
+                Photo(
+                    2,
+                    "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRMq7bQ-R0hiB4yRlqy90bmRwkA_maZnDX3_k0Xq7FYZ1jjxO5s44ivXRDBsfvCG4bYp_Q&usqp=CAU",
+                    "불국사",
+                    "신라 경덕왕 때 창건된 아름다운 사찰",
+                    "2025.06.15 10:30",
+                    listOf("사찰", "문화재", "신라", "단풍")
+                ),
+                Photo(
+                    3,
+                    "https://mblogthumb-phinf.pstatic.net/MjAyNDA5MjVfMTI0/MDAxNzI3MjE5NTk5MzMw.4O1M4YHD_HhT9A7H6dmgmnwmQjsxmZc9-aad_IbfBGog.sAIRyuBt2ze_X7euNNQas3KlHKrqtGWkKQCZmUZc0ikg.JPEG/DSC_4085.jpg?type=w800",
+                    "석굴암",
+                    "통일신라시대의 대표적인 석굴사원",
+                    "2025.06.15 14:00",
+                    listOf("국보", "불교미술", "조각", "일출")
+                ),
+                Photo(
+                    4,
+                    "https://myvenus.co.kr/files/attach/images/2040/672/424/fc318bed7159b3b00772faeab9e9ad2c.JPG",
+                    "동궁과 월지",
+                    "신라 왕궁의 별궁터, 야경이 아름다운 곳",
+                    "2025.06.16 20:00",
+                    listOf("야경명소", "궁궐", "연못", "신라역사")
+                ),
+                Photo(
+                    5,
+                    "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTU1gMflmj9fJzdTBwXKar33BAZ87TNuxr8JA&s",
+                    "황리단길",
+                    "전통과 현대가 어우러진 경주의 핫플레이스",
+                    "2025.06.17 11:00",
+                    listOf("한옥", "카페거리", "맛집탐방", "젊음의거리")
+                )
+            ), listOf("감동", "경건함", "가족애", "전통미", "평온", "역사")
+        ),
+        Album(
+            2, "부산 해변 드라이브", "2025.07.01", "2025.07.03", "부산시", listOf(
+                Photo(
+                    6,
+                    "https://www.saha.go.kr/tour/images/sub/img_01_01_01.jpg",
+                    "다대포 해수욕장",
+                    "넓은 백사장과 아름다운 일몰을 자랑하는 해변",
+                    "2025.07.01 18:30",
+                    listOf("일몰명소", "해수욕", "갯벌체험", "산책")
+                ),
+                Photo(
+                    7,
+                    "https://visitbusan.net/uploadImgs/files/cntnts/20221215173025725_oen",
+                    "해운대 해수욕장",
+                    "부산을 대표하는 유명한 해수욕장",
+                    "2025.07.02 15:00",
+                    listOf("백사장", "여름휴가", "바다수영", "축제")
+                ),
+                Photo(
+                    8,
+                    "https://cdn.epnc.co.kr/news/photo/202001/93682_85075_3859.jpg",
+                    "광안대교",
+                    "밤바다를 가로지르는 아름다운 다리, 야경 명소",
+                    "2025.07.02 21:00",
+                    listOf("야경드라이브", "불꽃축제", "바다전망", "랜드마크")
+                )
+            ), listOf("힐링", "바다", "낭만", "드라이브", "해변", "휴식", "야경", "맛집")
+        ),
+        Album(
+            3, "제주도 한라산 등반", "2025.08.10", "2025.08.12", "제주시", listOf(
+                Photo(
+                    9,
+                    "https://san.chosun.com/news/photo/201112/6500_22519_2612.jpg",
+                    "한라산 백록담",
+                    "한라산 정상에 위치한 화산호",
+                    "2025.08.11 12:00",
+                    listOf("정상", "화산", "등산", "자연경관")
+                ),
+                Photo(
+                    10,
+                    "https://cdn.mhns.co.kr/news/photo/202201/520746_630720_356.jpg",
+                    "한라산 관음사 코스",
+                    "한라산 등반 코스 중 하나, 아름다운 계곡 풍경",
+                    "2025.08.11 09:00",
+                    listOf("계곡", "숲길", "트레킹", "피톤치드")
+                )
+            ), listOf("도전", "자연", "성취감", "풍경")
+        )
     )
 }

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoAdapter.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoAdapter.kt
@@ -1,0 +1,51 @@
+package com.hyosimroad.hamkkae.presentation.main.photo_album.detail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import coil.transform.RoundedCornersTransformation
+import com.hyosimroad.hamkkae.databinding.ItemImageBinding
+import com.hyosimroad.hamkkae.domain.model.Album
+
+class PhotoAdapter(
+    private val onItemClickListener: (Int) -> Unit
+): ListAdapter<Album.Photo, PhotoAdapter.PhotoViewHolder>(PhotoDiffCallback) {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): PhotoViewHolder {
+        val binding = ItemImageBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return PhotoViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(
+        holder: PhotoViewHolder,
+        position: Int
+    ) {
+        holder.bind(getItem(position))
+    }
+
+    inner class PhotoViewHolder(private val binding: ItemImageBinding): RecyclerView.ViewHolder(binding.root){
+        fun bind(photo: Album.Photo){
+            binding.ivImage.load(photo.url){
+                transformations(RoundedCornersTransformation(16f))
+            }
+            binding.ivImage.setOnClickListener {
+                onItemClickListener(photo.id)
+            }
+        }
+    }
+}
+
+object PhotoDiffCallback : DiffUtil.ItemCallback<Album.Photo>() {
+    override fun areItemsTheSame(oldItem: Album.Photo, newItem: Album.Photo): Boolean {
+        return oldItem.id == newItem.id // id로 비교 (식별자)
+    }
+
+    override fun areContentsTheSame(oldItem: Album.Photo, newItem: Album.Photo): Boolean {
+        return oldItem == newItem // 데이터 클래스라면 자동 equals 비교 가능
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoAlbumDetailActivity.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoAlbumDetailActivity.kt
@@ -1,0 +1,102 @@
+package com.hyosimroad.hamkkae.presentation.main.photo_album.detail
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.flexbox.JustifyContent
+import com.hyosimroad.hamkkae.R
+import com.hyosimroad.hamkkae.databinding.ActivityPhotoAlbumDetailBinding
+import com.hyosimroad.hamkkae.presentation.main.photo_album.PhotoAlbumViewModel
+import com.hyosimroad.hamkkae.presentation.main.photo_album.TextAdapter
+import com.hyosimroad.hamkkae.util.GallerySaver
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import kotlin.getValue
+
+class PhotoAlbumDetailActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityPhotoAlbumDetailBinding
+    private val photoAlbumViewModel: PhotoAlbumViewModel by viewModels()
+    private val photoAlbumDetailViewModel: PhotoAlbumDetailViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initBinds()
+        setting()
+    }
+
+    private fun initBinds() {
+        binding = ActivityPhotoAlbumDetailBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
+
+    private fun setting() {
+        val id = intent.getIntExtra("albumId", 0)
+        photoAlbumDetailViewModel.album = photoAlbumViewModel.albumList[id - 1]
+
+        binding.tvTitle.text = photoAlbumDetailViewModel.album.name
+        binding.tvSubtitle.text = getString(
+            R.string.main_trip_record_during,
+            photoAlbumDetailViewModel.album.startDate,
+            photoAlbumDetailViewModel.album.endDate
+        )
+
+        setKeywords()
+        setPhotos()
+        downloadPhotos()
+    }
+
+    private fun setKeywords() {
+        val keywordAdapter = TextAdapter()
+        val flexboxLayoutManager = FlexboxLayoutManager(this).apply {
+            flexDirection = FlexDirection.ROW
+            flexWrap = FlexWrap.WRAP
+            justifyContent = JustifyContent.FLEX_START
+        }
+        binding.rvKeywords.layoutManager = flexboxLayoutManager
+        binding.rvKeywords.adapter = keywordAdapter
+        val modifyList = photoAlbumDetailViewModel.album.keywords.map {
+            getString(
+                R.string.photo_album_tag,
+                it
+            )
+        }
+        keywordAdapter.submitList(modifyList)
+    }
+
+    private fun setPhotos() {
+        with(binding) {
+            tvPhotoCount.text = getString(
+                R.string.photo_album_detail_photo_count,
+                photoAlbumDetailViewModel.album.photos.size
+            )
+
+            val photoAdapter = PhotoAdapter(onItemClickListener = { photoId ->
+                Timber.d("id: $photoId")
+                val dialog = PhotoAlbumDetailDialogFragment.newInstance(photoId)
+                dialog.show(supportFragmentManager, "PhotoAlbumDetailDialogFragment")
+            })
+            rvPhotos.adapter = photoAdapter
+            photoAdapter.submitList(photoAlbumDetailViewModel.album.photos)
+        }
+    }
+
+    private fun downloadPhotos(){
+        binding.btnDownload.setOnClickListener {
+            lifecycleScope.launch {
+                val photoList = photoAlbumDetailViewModel.album.photos.map{it.url}
+                if(photoList.isEmpty()){
+                    Toast.makeText(this@PhotoAlbumDetailActivity, "저장할 사진이 없어요.", Toast.LENGTH_SHORT).show()
+                    return@launch
+                }
+
+                val count = GallerySaver.saveUrls(this@PhotoAlbumDetailActivity, photoList, "Pictures/hamkkae")
+                Toast.makeText(this@PhotoAlbumDetailActivity, "${count}개의 사진을 저장했습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoAlbumDetailDialogFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoAlbumDetailDialogFragment.kt
@@ -1,0 +1,86 @@
+package com.hyosimroad.hamkkae.presentation.main.photo_album.detail
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModelProvider
+import androidx.viewpager2.widget.ViewPager2
+import coil.load
+import com.hyosimroad.hamkkae.R
+import com.hyosimroad.hamkkae.databinding.DialogPhotoDetailBinding
+import com.hyosimroad.hamkkae.presentation.main.plan.recommend.detail.tip.TextAdapter
+import timber.log.Timber
+
+class PhotoAlbumDetailDialogFragment : DialogFragment() {
+    private var _binding: DialogPhotoDetailBinding? = null
+    private val binding get() = _binding!!
+    private val photoAlbumDetailViewModel: PhotoAlbumDetailViewModel by activityViewModels()
+
+    companion object {
+        private const val ARG_PHOTO_ID = "photo_id"
+
+        fun newInstance(photoId: Int): PhotoAlbumDetailDialogFragment {
+            val fragment = PhotoAlbumDetailDialogFragment()
+            val args = Bundle().apply {
+                putInt(ARG_PHOTO_ID, photoId)
+            }
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // 다이얼로그의 배경을 투명하게 설정
+        dialog?.window?.setBackgroundDrawableResource(android.R.color.transparent)
+        // 다이얼로그의 레이아웃 크기 설정 (원하는 크기로 조절)
+        dialog?.window?.setLayout(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogPhotoDetailBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setting()
+    }
+
+    private fun setting() {
+        val photoId = arguments?.getInt(ARG_PHOTO_ID)
+        Timber.d("photoId: $photoId")
+
+        val photoPagerAdapter = PhotoPagerAdapter()
+        binding.vpPhotos.adapter = photoPagerAdapter
+        photoPagerAdapter.submitList(photoAlbumDetailViewModel.album.photos)
+
+        val clickedPhotoIndex = photoAlbumDetailViewModel.album.photos.indexOfFirst { it.id == photoId }
+        binding.vpPhotos.setCurrentItem(clickedPhotoIndex, false)
+
+        binding.vpPhotos.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                binding.tvNumOfPhoto.text = getString(R.string.photo_album_detail_num_of_photo, position + 1, photoPagerAdapter.itemCount)
+            }
+        })
+
+        binding.btnClose.setOnClickListener {
+            dismiss() // 팝업 닫기
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoAlbumDetailViewModel.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoAlbumDetailViewModel.kt
@@ -1,0 +1,8 @@
+package com.hyosimroad.hamkkae.presentation.main.photo_album.detail
+
+import androidx.lifecycle.ViewModel
+import com.hyosimroad.hamkkae.domain.model.Album
+
+class PhotoAlbumDetailViewModel: ViewModel() {
+    lateinit var album: Album
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoPagerAdapter.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/photo_album/detail/PhotoPagerAdapter.kt
@@ -1,0 +1,70 @@
+package com.hyosimroad.hamkkae.presentation.main.photo_album.detail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import coil.transform.RoundedCornersTransformation
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexWrap
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.hyosimroad.hamkkae.R
+import com.hyosimroad.hamkkae.databinding.ItemPhotoPagerBinding
+import com.hyosimroad.hamkkae.domain.model.Album
+import com.hyosimroad.hamkkae.domain.model.Album.*
+import com.hyosimroad.hamkkae.presentation.main.photo_album.TextAdapter
+
+// PhotoPagerAdapter.kt
+class PhotoPagerAdapter : ListAdapter<Photo, PhotoPagerAdapter.PhotoViewHolder>(PhotoPagerDiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PhotoViewHolder {
+        val binding = ItemPhotoPagerBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return PhotoViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: PhotoViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class PhotoViewHolder(private val binding: ItemPhotoPagerBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(photo: Photo) {
+            val flexboxLayoutManager = FlexboxLayoutManager(binding.root.context).apply {
+                flexWrap = FlexWrap.WRAP
+                flexDirection = FlexDirection.ROW
+            }
+
+            with(binding){
+                ivPhoto.load(photo.url){
+                    transformations(RoundedCornersTransformation(16f))
+                }
+                tvPlace.text = photo.place
+                tvTime.text = photo.time
+                tvDescription.text = photo.description
+
+                val keywordAdapter = TextAdapter()
+                rvKeywords.layoutManager = flexboxLayoutManager
+                rvKeywords.adapter = keywordAdapter
+
+                val modifyList = photo.keywords.map {
+                    binding.root.context.getString(
+                        R.string.photo_album_tag,
+                        it
+                    )
+                }
+                keywordAdapter.submitList(modifyList)
+            }
+        }
+    }
+}
+
+object PhotoPagerDiffCallback : DiffUtil.ItemCallback<Photo>() {
+    override fun areItemsTheSame(oldItem: Photo, newItem: Photo): Boolean {
+        return oldItem.id == newItem.id // id로 비교 (식별자)
+    }
+
+    override fun areContentsTheSame(oldItem: Photo, newItem: Photo): Boolean {
+        return oldItem == newItem // 데이터 클래스라면 자동 equals 비교 가능
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/util/GallerySaver.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/util/GallerySaver.kt
@@ -1,0 +1,129 @@
+package com.hyosimroad.hamkkae.util
+
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.InputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+
+object GallerySaver {
+
+    suspend fun saveUris(
+        context: Context,
+        uris: List<Uri>,
+        subDir: String = "Pictures/MyApp"
+    ): Int = withContext(Dispatchers.IO) {
+        var saved = 0
+        for ((idx, src) in uris.withIndex()) {
+            runCatching {
+                context.contentResolver.openInputStream(src)?.use { inS ->
+                    val name = "photo_${System.currentTimeMillis()}_${idx}.jpg"
+                    saveStream(context, inS, name, subDir)
+                }
+            }.onSuccess { saved++ }
+        }
+        saved
+    }
+
+    suspend fun saveBitmaps(
+        context: Context,
+        bitmaps: List<Bitmap>,
+        subDir: String = "Pictures/MyApp"
+    ): Int = withContext(Dispatchers.IO) {
+        var saved = 0
+        for ((idx, bmp) in bitmaps.withIndex()) {
+            runCatching {
+                val name = "photo_${System.currentTimeMillis()}_${idx}.jpg"
+                val pipe = PipedOutputStream()
+                val inS = PipedInputStream(pipe)
+                // 비동기로 JPEG로 압축해 파이프에 씀
+                launch {
+                    bmp.compress(Bitmap.CompressFormat.JPEG, 95, pipe)
+                    pipe.close()
+                }
+                saveStream(context, inS, name, subDir)
+            }.onSuccess { saved++ }
+        }
+        saved
+    }
+
+    suspend fun saveUrls(
+        context: Context,
+        urls: List<String>,
+        subDir: String = "Pictures/MyApp"
+    ): Int = withContext(Dispatchers.IO) {
+        var saved = 0
+        val ok = okhttp3.OkHttpClient()
+        for ((idx, u) in urls.withIndex()) {
+            runCatching {
+                val resp = ok.newCall(
+                    okhttp3.Request.Builder().url(u).build()
+                ).execute()
+                resp.body?.byteStream()?.use { inS ->
+                    val ext = guessExt(resp.body?.contentType()?.toString())
+                    val name = "photo_${System.currentTimeMillis()}_${idx}.${ext}"
+                    saveStream(context, inS, name, subDir,
+                        mime = mimeFromExt(ext))
+                }
+            }.onSuccess { saved++ }
+        }
+        saved
+    }
+
+    private fun guessExt(ct: String?): String =
+        when {
+            ct?.contains("png", true) == true -> "png"
+            ct?.contains("webp", true) == true -> "webp"
+            else -> "jpg"
+        }
+    private fun mimeFromExt(ext: String) =
+        when (ext.lowercase()) {
+            "png" -> "image/png"
+            "webp" -> "image/webp"
+            else -> "image/jpeg"
+        }
+
+    private fun saveStream(
+        context: Context,
+        inS: InputStream,
+        displayName: String,
+        subDir: String,
+        mime: String = "image/jpeg"
+    ) {
+        val resolver = context.contentResolver
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, displayName)
+            put(MediaStore.Images.Media.MIME_TYPE, mime)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put(MediaStore.Images.Media.RELATIVE_PATH, subDir) // 예: Pictures/MyApp
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            } else {
+                val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
+                val file = File(dir, displayName)
+                put(MediaStore.Images.Media.DATA, file.absolutePath)
+            }
+        }
+
+        val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+            ?: throw IllegalStateException("Failed to create MediaStore record")
+
+        resolver.openOutputStream(uri)?.use { outS ->
+            inS.copyTo(outS)
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            values.clear()
+            values.put(MediaStore.Images.Media.IS_PENDING, 0)
+            resolver.update(uri, values, null, null)
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_close_white_24.xml
+++ b/app/src/main/res/drawable/ic_close_white_24.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18.3,5.71c-0.39,-0.39 -1.02,-0.39 -1.41,0L12,10.59 7.11,5.7c-0.39,-0.39 -1.02,-0.39 -1.41,0 -0.39,0.39 -0.39,1.02 0,1.41L10.59,12 5.7,16.89c-0.39,0.39 -0.39,1.02 0,1.41 0.39,0.39 1.02,0.39 1.41,0L12,13.41l4.89,4.89c0.39,0.39 1.02,0.39 1.41,0 0.39,-0.39 0.39,-1.02 0,-1.41L13.41,12l4.89,-4.89c0.38,-0.38 0.38,-1.02 0,-1.4z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_download_gray_24.xml
+++ b/app/src/main/res/drawable/ic_download_gray_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="@color/text_secondary_gray"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,15v3H6v-3H4v3c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2v-3H18z
+                          M7,11l1.41,-1.41L11,12.17V4h2v8.17l2.59,-2.58L17,11l-5,5L7,11z" />
+
+</vector>

--- a/app/src/main/res/layout/activity_photo_album.xml
+++ b/app/src/main/res/layout/activity_photo_album.xml
@@ -118,7 +118,7 @@
                 android:id="@+id/tv_total_days"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/photo_album_total_days"
+                android:text="@string/photo_album_in_process"
                 android:textColor="@color/text_secondary_gray"
                 app:layout_constraintTop_toTopOf="@id/tv_total_album"
                 app:layout_constraintStart_toEndOf="@id/tv_total_photos"

--- a/app/src/main/res/layout/activity_photo_album_detail.xml
+++ b/app/src/main/res/layout/activity_photo_album_detail.xml
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_yellow">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_back"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                android:background="@drawable/ic_back_black_24"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintDimensionRatio="1:1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_percent="0.08" />
+
+            <TextView
+                android:id="@+id/tv_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="20dp"
+                android:text="@string/photo_album_title"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toTopOf="@id/tv_subtitle"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/btn_back"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_subtitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="20dp"
+                android:text="@string/photo_album_subtitle"
+                android:textColor="@color/text_secondary_gray"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/tv_title"
+                app:layout_constraintStart_toStartOf="@id/tv_title"
+                app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+            <View
+                android:id="@+id/v_line"
+                android:layout_width="match_parent"
+                android:layout_height="2dp"
+                android:background="@color/header_line_orange"
+                app:layout_constraintBottom_toBottomOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cv_keywords"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            app:cardBackgroundColor="@color/white"
+            app:cardElevation="2dp"
+            app:cardCornerRadius="10dp"
+            app:layout_constraintTop_toBottomOf="@id/cl_header"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_keywords"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+               <TextView
+                   android:id="@+id/tv_trip_keyword"
+                   android:layout_width="wrap_content"
+                   android:layout_height="wrap_content"
+                   android:text="@string/photo_album_detail_trip_keywords"
+                   android:textSize="18sp"
+                   android:textStyle="bold"
+                   android:layout_marginTop="22dp"
+                   android:layout_marginStart="20dp"
+                   app:layout_constraintTop_toTopOf="parent"
+                   app:layout_constraintStart_toStartOf="parent"/>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_keywords"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="20dp"
+                    android:layout_marginTop="20dp"
+                    android:nestedScrollingEnabled="false"
+                    app:layout_constraintTop_toBottomOf="@id/tv_trip_keyword"
+                    app:layout_constraintStart_toStartOf="@id/tv_trip_keyword"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+                <TextView
+                    android:id="@+id/tv_ai_comment"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/photo_album_detail_ai_comment"
+                    android:textSize="14sp"
+                    android:textColor="@color/text_secondary_gray"
+                    android:layout_marginTop="15dp"
+                    android:layout_marginBottom="20dp"
+                    app:layout_constraintTop_toBottomOf="@id/rv_keywords"
+                    app:layout_constraintStart_toStartOf="@id/rv_keywords"
+                    app:layout_constraintEnd_toEndOf="@id/rv_keywords"
+                    app:layout_constraintBottom_toBottomOf="parent"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cv_photos"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginTop="20dp"
+            app:cardBackgroundColor="@color/white"
+            app:cardElevation="2dp"
+            app:cardCornerRadius="10dp"
+            app:layout_constraintTop_toBottomOf="@id/cv_keywords"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_photos"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:id="@+id/tv_galary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/photo_album_detail_galary"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginStart="18dp"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"/>
+
+                <TextView
+                    android:id="@+id/tv_photo_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="18dp"
+                    android:text="6장"
+                    android:textColor="@color/text_secondary_gray"
+                    android:paddingStart="15dp"
+                    android:paddingEnd="15dp"
+                    android:background="@drawable/bg_place_outline"
+                    app:layout_constraintTop_toTopOf="@id/tv_galary"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_galary"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rv_photos"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp"
+                    android:layout_marginBottom="20dp"
+                    android:nestedScrollingEnabled="false"
+                    app:spanCount="2"
+                    app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                    app:layout_constraintTop_toBottomOf="@id/tv_galary"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/tv_galary"
+                    app:layout_constraintEnd_toEndOf="@id/tv_photo_count"
+                    tools:listitem="@layout/item_image"/>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_share"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="20dp"
+            android:background="@drawable/bg_white_stroke"
+            app:layout_constraintTop_toBottomOf="@id/cv_photos"
+            app:layout_constraintStart_toStartOf="@id/cv_photos"
+            app:layout_constraintEnd_toEndOf="@id/cv_photos"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <TextView
+                android:id="@+id/tv_memory_share"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="15dp"
+                android:layout_marginStart="15dp"
+                android:text="@string/photo_album_detail_memory_share"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_share"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginBottom="20dp"
+                android:layout_marginEnd="5dp"
+                android:layout_marginTop="20dp"
+                android:text="@string/photo_album_detail_share"
+                android:textAllCaps="false"
+                android:textColor="@color/text_secondary_gray"
+                android:textStyle="bold"
+                android:textSize="15sp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:paddingVertical="0dp"
+                app:cornerRadius="5dp"
+                app:strokeColor="@color/state_complete_gray"
+                app:strokeWidth="1dp"
+                app:backgroundTint="@color/white"
+                app:icon="@drawable/ic_share_gray_24"
+                app:iconTint="@color/text_secondary_gray"
+                app:iconGravity="textStart"
+                app:layout_constraintTop_toBottomOf="@id/tv_memory_share"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/btn_download"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_download"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginStart="5dp"
+                android:layout_marginBottom="20dp"
+                android:text="@string/photo_album_detail_download"
+                android:textAllCaps="false"
+                android:textColor="@color/text_secondary_gray"
+                android:textStyle="bold"
+                android:textSize="15sp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:paddingVertical="0dp"
+                app:cornerRadius="5dp"
+                app:strokeColor="@color/state_complete_gray"
+                app:strokeWidth="1dp"
+                app:backgroundTint="@color/white"
+                app:icon="@drawable/ic_download_gray_24"
+                app:iconTint="@color/text_secondary_gray"
+                app:iconGravity="textStart"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/btn_share"
+                app:layout_constraintEnd_toEndOf="parent"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/dialog_photo_detail.xml
+++ b/app/src/main/res/layout/dialog_photo_detail.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageButton
+        android:id="@+id/btn_close"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:elevation="10dp"
+        android:src="@drawable/ic_close_white_24"
+        android:layout_marginTop="20dp"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintWidth_percent="0.14"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_num_of_photo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="1 / 6"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        app:layout_constraintTop_toTopOf="@id/btn_close"
+        app:layout_constraintBottom_toBottomOf="@id/btn_close"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/vp_photos"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_num_of_photo"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_image.xml
+++ b/app/src/main/res/layout/item_image.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <ImageView
         android:id="@+id/iv_image"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:scaleType="centerCrop"
+        android:layout_margin="5dp"
         app:layout_constraintDimensionRatio="1:0.8"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_photo_pager.xml
+++ b/app/src/main/res/layout/item_photo_pager.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/card_popup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        app:cardCornerRadius="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/tv_place"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="불국사"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:layout_marginTop="16dp"
+                android:layout_marginStart="20dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"/>
+
+            <TextView
+                android:id="@+id/tv_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="2025.07.15 09:30"
+                android:textSize="13sp"
+                android:textColor="@color/text_secondary_gray"
+                app:layout_constraintTop_toBottomOf="@id/tv_place"
+                app:layout_constraintStart_toStartOf="@id/tv_place"/>
+
+            <ImageView
+                android:id="@+id/iv_photo"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:src="@drawable/image_trip"
+                android:layout_marginTop="10dp"
+                app:layout_constraintDimensionRatio="1:0.6"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_time" />
+
+
+            <TextView
+                android:id="@+id/tv_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="불국사 앞에서 찍은 가족사진..."
+                android:textColor="@color/text_secondary_gray"
+                app:layout_constraintStart_toStartOf="@id/tv_place"
+                app:layout_constraintTop_toBottomOf="@id/iv_photo" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_keywords"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                android:layout_marginBottom="16dp"
+                android:layout_marginEnd="20dp"
+                app:layout_constraintTop_toBottomOf="@id/tv_description"
+                app:layout_constraintStart_toStartOf="@id/tv_description"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,7 +52,7 @@
 
     <string name="main_trip_record_title">여행 기록</string>
     <string name="main_trip_record_no_content">아직 여행 기록이 없어요!</string>
-    <string name="main_trip_record_date">%s ~ %s</string>
+    <string name="main_trip_record_during">%s ~ %s</string>
 
 
     <!--plan-->
@@ -151,11 +151,21 @@
     <string name="photo_album_statistics">📊 앨범 통계</string>
     <string name="photo_album_total_albums">총 앨범</string>
     <string name="photo_album_total_photos">총 사진</string>
-    <string name="photo_album_total_days">총 여행일</string>
+    <string name="photo_album_in_process">진행중</string>
     <string name="photo_album_trip_album">여행 앨범</string>
     <string name="photo_album_none">아직 앨범이 없네요 😣\n여행 계획부터 세워볼까요?</string>
     <string name="photo_album_info_format">%s • %d장</string>
     <string name="photo_album_tag">#%s</string>
+
+    <!--photo_album_detail-->
+    <string name="photo_album_detail_trip_keywords">여행 키워드</string>
+    <string name="photo_album_detail_ai_comment">AI가 분석한 이번 여행의 감정과 순간들이에요 🤗</string>
+    <string name="photo_album_detail_galary">사진 갤러리</string>
+    <string name="photo_album_detail_photo_count">%d장</string>
+    <string name="photo_album_detail_num_of_photo">%1$d / %2$d</string>
+    <string name="photo_album_detail_memory_share">🖼️ 추억 공유하기</string>
+    <string name="photo_album_detail_share">공유</string>
+    <string name="photo_album_detail_download">사진 저장</string>
 
 
 


### PR DESCRIPTION
[추억 사진첩 디자인 변경]
- 앨범 통계의 총 여행일 부분을 다시 진행중으로 변경

[추억 사진첩 상세화면 디자인 변경]
- 여행 상세 정보와 사진 + 정보 부분을 없앰
- 여행 이름과 날짜는 화면 상단에, 키워드는 그 아래에 표시
- 아래에는 사진만 보이는 갤러리 추가
  - 사진 터치 시 dialog를 통해 해당 사진을 촬영한 위치, 촬영 날짜 및 시간, 설명, 키워드가 보이고 사진이 좀 더 크게 보임
  - 좌우 스크롤로 다른 사진도 볼 수 있음
- 제일 하단에는 공유와 다운로드 버튼 추가


https://github.com/user-attachments/assets/19247fa6-adf0-4be0-b44b-2dab46225576

