### PR TITLE
feat: login-signup #33

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,14 +21,23 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Hamkkae">
-        <activity
-            android:name=".presentation.main.MainActivity"
+
+        <activity android:name=".presentation.main.auth.AuthActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".presentation.main.MainActivity"
+            android:exported="true">
+<!--            <intent-filter>-->
+<!--                <action android:name="android.intent.action.MAIN" />-->
+
+<!--                <category android:name="android.intent.category.LAUNCHER" />-->
+<!--            </intent-filter>-->
         </activity>
 
         <activity android:name=".presentation.main.plan.PlanActivity"

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/AuthActivity.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/AuthActivity.kt
@@ -1,0 +1,20 @@
+package com.hyosimroad.hamkkae.presentation.main.auth
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.hyosimroad.hamkkae.databinding.ActivityAuthBinding
+import com.hyosimroad.hamkkae.databinding.ActivityPlanBinding
+
+class AuthActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityAuthBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initBinds()
+    }
+
+    private fun initBinds() {
+        binding = ActivityAuthBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/find/FindFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/find/FindFragment.kt
@@ -1,0 +1,120 @@
+package com.hyosimroad.hamkkae.presentation.main.auth.find
+
+import android.graphics.Typeface
+import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.AbsoluteSizeSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.text.style.UnderlineSpan
+import android.util.TypedValue
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.tabs.TabLayout
+import com.hyosimroad.hamkkae.R
+import com.hyosimroad.hamkkae.databinding.FragmentFindBinding
+import timber.log.Timber
+
+class FindFragment : Fragment() {
+    private var _binding: FragmentFindBinding? = null
+    private val binding: FragmentFindBinding
+        get() = requireNotNull(_binding) { "Find fragment is null" }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentFindBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Timber.d("FingFragment started!")
+
+        setupTab()
+        applySpannableStyle(
+            textView = binding.tvToLogin,
+            fullTextResId = R.string.find_to_login,
+            targetText = "로그인"
+        )
+
+        clickLoginButton()
+    }
+
+    private fun setupTab() {
+        binding.tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab?) {
+                when (tab?.position) {
+                    0 -> replaceFragment(FindIdFragment())
+                    1 -> replaceFragment(FindPwFragment())
+                }
+            }
+            override fun onTabUnselected(tab: TabLayout.Tab?) {}
+            override fun onTabReselected(tab: TabLayout.Tab?) {}
+        })
+
+        binding.tabLayout.addTab(binding.tabLayout.newTab().setText(getString(R.string.find_id_button)))
+        binding.tabLayout.addTab(binding.tabLayout.newTab().setText(getString(R.string.find_pw_button)))
+    }
+
+    private fun replaceFragment(fragment: Fragment) {
+        childFragmentManager.commit {
+            replace(R.id.fragment_container, fragment)
+            setReorderingAllowed(true)
+        }
+    }
+
+    private fun applySpannableStyle(
+        textView: TextView,
+        @StringRes fullTextResId: Int,
+        targetText: String
+    ) {
+        val fullText = getString(fullTextResId)
+        val spannableString = SpannableString(fullText)
+        val startIndex = fullText.indexOf(targetText)
+
+        if (startIndex != -1) {
+            val endIndex = startIndex + targetText.length
+            val color = ContextCompat.getColor(requireContext(), R.color.auth_box_orange)
+
+            val sizeInPx = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                16f,
+                resources.displayMetrics
+            ).toInt()
+
+            spannableString.setSpan(StyleSpan(Typeface.BOLD_ITALIC), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(UnderlineSpan(), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(ForegroundColorSpan(color), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(AbsoluteSizeSpan(sizeInPx), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+
+        textView.text = spannableString
+    }
+
+    private fun clickLoginButton() {
+        binding.tvToLogin.setOnClickListener {
+            findNavController().navigate(
+                R.id.action_findFragment_to_loginFragment,
+                null,
+                NavOptions.Builder()
+                    .setPopUpTo(R.id.findFragment, true)
+                    .build()
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/find/FindIdFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/find/FindIdFragment.kt
@@ -1,0 +1,35 @@
+package com.hyosimroad.hamkkae.presentation.main.auth.find
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.hyosimroad.hamkkae.R
+import com.hyosimroad.hamkkae.databinding.FragmentFindIdBinding
+import timber.log.Timber
+
+class FindIdFragment : Fragment() {
+    private var _binding: FragmentFindIdBinding? = null
+    private val binding: FragmentFindIdBinding
+        get() = requireNotNull(_binding) { "Find fragment is null" }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentFindIdBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Timber.d("FingFragment started!")
+
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/find/FindPwFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/find/FindPwFragment.kt
@@ -1,0 +1,33 @@
+package com.hyosimroad.hamkkae.presentation.main.auth.find
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.hyosimroad.hamkkae.databinding.FragmentFindPwBinding
+import timber.log.Timber
+
+class FindPwFragment : Fragment() {
+    private var _binding: FragmentFindPwBinding? = null
+    private val binding: FragmentFindPwBinding
+        get() = requireNotNull(_binding) { "FindPwFragment binding is null" }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentFindPwBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Timber.d("FindPwFragment started!")
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/find/adapter/FindViewPagerAdapter.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/find/adapter/FindViewPagerAdapter.kt
@@ -1,0 +1,17 @@
+package com.hyosimroad.hamkkae.presentation.main.auth.find.adapter
+
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.hyosimroad.hamkkae.presentation.main.auth.find.FindIdFragment
+import com.hyosimroad.hamkkae.presentation.main.auth.find.FindPwFragment
+
+class FindViewPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
+    override fun getItemCount(): Int = 2
+
+    override fun createFragment(position: Int): Fragment {
+        return when (position) {
+            0 -> FindIdFragment()
+            else -> FindPwFragment()
+        }
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/login/LoginFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/login/LoginFragment.kt
@@ -1,0 +1,111 @@
+package com.hyosimroad.hamkkae.presentation.main.auth.login
+
+import android.content.Intent
+import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.text.style.UnderlineSpan
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.graphics.Typeface
+import android.text.style.AbsoluteSizeSpan
+import android.util.TypedValue
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.hyosimroad.hamkkae.R
+import com.hyosimroad.hamkkae.databinding.FragmentLoginBinding
+import com.hyosimroad.hamkkae.presentation.main.MainActivity
+import timber.log.Timber
+
+class LoginFragment : Fragment() {
+    private var _binding: FragmentLoginBinding? = null
+    private val binding: FragmentLoginBinding
+        get() = requireNotNull(_binding) { "login fragment is null" }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentLoginBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Timber.d("LoginFragment started!")
+
+        applySpannableStyle(
+            textView = binding.tvToSignup,
+            fullTextResId = R.string.login_to_join,
+            targetText = "회원가입"
+        )
+
+        applySpannableStyle(
+            textView = binding.tvToFind,
+            fullTextResId = R.string.login_to_find,
+            targetText = "아이디, 비밀번호 찾기"
+        )
+
+        clickLoginButton()
+        clickSignupButton()
+        clickFindButton()
+    }
+
+    private fun applySpannableStyle(
+        textView: TextView,
+        @StringRes fullTextResId: Int,
+        targetText: String
+    ) {
+        val fullText = getString(fullTextResId)
+        val spannableString = SpannableString(fullText)
+        val startIndex = fullText.indexOf(targetText)
+
+        if (startIndex != -1) {
+            val endIndex = startIndex + targetText.length
+            val color = ContextCompat.getColor(requireContext(), R.color.auth_box_orange)
+
+            val sizeInPx = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                16f,
+                resources.displayMetrics
+            ).toInt()
+
+            spannableString.setSpan(StyleSpan(Typeface.BOLD_ITALIC), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(UnderlineSpan(), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(ForegroundColorSpan(color), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(AbsoluteSizeSpan(sizeInPx), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+
+        textView.text = spannableString
+    }
+
+    private fun clickLoginButton() {
+        binding.btnLogin.setOnClickListener {
+            val intent = Intent(requireContext(), MainActivity::class.java)
+            startActivity(intent)
+            requireActivity().finish()
+        }
+    }
+
+    private fun clickSignupButton() {
+        binding.tvToSignup.setOnClickListener {
+            findNavController().navigate(R.id.action_loginFragment_to_signupAgreeFragment)
+        }
+    }
+
+    private fun clickFindButton() {
+        binding.tvToFind.setOnClickListener {
+            findNavController().navigate(R.id.action_loginFragment_to_findFragment)
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/signup/SignupAgreeFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/signup/SignupAgreeFragment.kt
@@ -1,0 +1,103 @@
+package com.hyosimroad.hamkkae.presentation.main.auth.signup
+
+import android.content.Intent
+import android.graphics.Typeface
+import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.AbsoluteSizeSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.text.style.UnderlineSpan
+import android.util.TypedValue
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import com.hyosimroad.hamkkae.R
+import com.hyosimroad.hamkkae.databinding.FragmentSignupAgreeBinding
+import com.hyosimroad.hamkkae.presentation.main.MainActivity
+import timber.log.Timber
+
+class SignupAgreeFragment: Fragment() {
+    private var _binding: FragmentSignupAgreeBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentSignupAgreeBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Timber.d("SignupAgreeFragment started!")
+
+        applySpannableStyle(
+            textView = binding.tvToLoginFromSignupAgree,
+            fullTextResId = R.string.signup_to_login,
+            targetText = "로그인"
+        )
+
+        clickNextButton()
+        clickLoginButton()
+    }
+
+    private fun applySpannableStyle(
+        textView: TextView,
+        @StringRes fullTextResId: Int,
+        targetText: String
+    ) {
+        val fullText = getString(fullTextResId)
+        val spannableString = SpannableString(fullText)
+        val startIndex = fullText.indexOf(targetText)
+
+        if (startIndex != -1) {
+            val endIndex = startIndex + targetText.length
+            val color = ContextCompat.getColor(requireContext(), R.color.auth_box_orange)
+
+            val sizeInPx = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                16f,
+                resources.displayMetrics
+            ).toInt()
+
+            spannableString.setSpan(StyleSpan(Typeface.BOLD_ITALIC), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(UnderlineSpan(), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(ForegroundColorSpan(color), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(AbsoluteSizeSpan(sizeInPx), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+
+        textView.text = spannableString
+    }
+
+    private fun clickNextButton() {
+        binding.btnNext.setOnClickListener {
+            findNavController().navigate(R.id.action_signupAgreeFragment_to_signupInfoFragment)
+        }
+    }
+
+    private fun clickLoginButton() {
+        binding.tvToLoginFromSignupAgree.setOnClickListener {
+            findNavController().navigate(
+                R.id.action_signupAgreeFragment_to_loginFragment,
+                null,
+                NavOptions.Builder()
+                    .setPopUpTo(R.id.signupAgreeFragment, true)
+                    .build()
+            )
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/signup/SignupInfoFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/auth/signup/SignupInfoFragment.kt
@@ -1,0 +1,126 @@
+package com.hyosimroad.hamkkae.presentation.main.auth.signup
+
+import android.graphics.Typeface
+import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.AbsoluteSizeSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
+import android.text.style.UnderlineSpan
+import android.util.TypedValue
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import com.hyosimroad.hamkkae.R
+import com.hyosimroad.hamkkae.databinding.FragmentSignupInfoBinding
+import timber.log.Timber
+
+class SignupInfoFragment : Fragment() {
+    private var _binding: FragmentSignupInfoBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentSignupInfoBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Timber.d("SignupIngoFragment started!")
+
+        applySpannableStyle(
+            textView = binding.tvToLogin,
+            fullTextResId = R.string.signup_to_login,
+            targetText = "로그인"
+        )
+
+        clickSignupButton()
+        clickLoginButton()
+    }
+
+    private fun applySpannableStyle(
+        textView: TextView,
+        @StringRes fullTextResId: Int,
+        targetText: String
+    ) {
+        val fullText = getString(fullTextResId)
+        val spannableString = SpannableString(fullText)
+        val startIndex = fullText.indexOf(targetText)
+
+        if (startIndex != -1) {
+            val endIndex = startIndex + targetText.length
+            val color = ContextCompat.getColor(requireContext(), R.color.auth_box_orange)
+
+            val sizeInPx = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                16f,
+                resources.displayMetrics
+            ).toInt()
+
+            spannableString.setSpan(StyleSpan(Typeface.BOLD_ITALIC), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(UnderlineSpan(), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(ForegroundColorSpan(color), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            spannableString.setSpan(AbsoluteSizeSpan(sizeInPx), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+
+        textView.text = spannableString
+    }
+
+    private fun checkId() {
+
+    }
+
+    private fun checkPw() {
+
+    }
+
+    private fun checkEmail() {
+
+    }
+
+    private fun checkCode() {
+
+    }
+
+    private fun clickSignupButton() {
+        binding.btnSignup.setOnClickListener {
+            findNavController().navigate(
+                R.id.action_signupInfoFragment_to_loginFragment,
+                null,
+                NavOptions.Builder()
+                    .setPopUpTo(R.id.signupInfoFragment, true)
+                    .setPopUpTo(R.id.signupAgreeFragment, true)
+                    .build()
+            )
+        }
+    }
+
+    private fun clickLoginButton() {
+        binding.tvToLogin.setOnClickListener {
+            findNavController().navigate(
+                R.id.action_signupInfoFragment_to_loginFragment,
+                null,
+                NavOptions.Builder()
+                    .setPopUpTo(R.id.signupInfoFragment, true)
+                    .setPopUpTo(R.id.signupAgreeFragment, true)
+                    .build()
+            )
+        }
+
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/plan/select/SelectTripInfoFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/main/plan/select/SelectTripInfoFragment.kt
@@ -20,7 +20,7 @@ import java.util.Locale
 class SelectTripInfoFragment : Fragment() {
     private var _binding: FragmentSelectTripInfoBinding? = null
     private val binding: FragmentSelectTripInfoBinding
-        get() = requireNotNull(_binding) { "home fragment is null" }
+        get() = requireNotNull(_binding) { "plan-trip-info fragment is null" }
 
     private var selectedStartDate: String? = null
     private var selectedEndDate: String? = null

--- a/app/src/main/res/drawable/tab_background.xml
+++ b/app/src/main/res/drawable/tab_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/white" />
+    <corners android:radius="10dp" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/auth_box_gray" />
+</shape>

--- a/app/src/main/res/drawable/tab_item_selector.xml
+++ b/app/src/main/res/drawable/tab_item_selector.xml
@@ -1,0 +1,16 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/primary_orange" />
+            <corners android:radius="10dp"/>
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent"/>
+            <corners android:radius="10dp"/>
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_yellow">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/iv_icon"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:layout_marginTop="80dp"
+            android:src="@drawable/ic_hamkkae"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/auth_fragment_container"
+            android:name="androidx.navigation.fragment.NavHostFragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="-10dp"
+            app:defaultNavHost="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_icon"
+            app:navGraph="@navigation/auth_nav_graph" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/fragment_find.xml
+++ b/app/src/main/res/layout/fragment_find.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/find_title"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/find_subtitle"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+    <FrameLayout
+        android:id="@+id/tabContainer"
+        android:layout_width="0dp"
+        android:layout_height="45dp"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="20dp"
+        android:background="@drawable/tab_background"
+        android:padding="3dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_subtitle">
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/transparent"
+            app:tabBackground="@drawable/tab_item_selector"
+            app:tabIndicatorColor="@color/primary_orange"
+            app:tabIndicatorHeight="0dp"
+            app:tabRippleColor="@android:color/transparent"
+            app:tabSelectedTextColor="@android:color/white"
+            app:tabTextColor="@color/black" />
+    </FrameLayout>
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tabContainer" />
+
+    <TextView
+        android:id="@+id/tv_to_login"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:text="@string/find_to_login"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/fragment_container" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_find_id.xml
+++ b/app/src/main/res/layout/fragment_find_id.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/tv_email_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="35dp"
+        android:layout_marginStart="2dp"
+        android:text="@string/find_id_email_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_email"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_email"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_email_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_email"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:boxBackgroundColor="@android:color/white"
+            app:boxBackgroundMode="none"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etEmail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:hint="@string/find_id_email"
+                android:inputType="textEmailAddress"
+                android:paddingVertical="15dp" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_login"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="45dp"
+        android:layout_marginBottom="5dp"
+        android:layout_marginHorizontal="32dp"
+        android:background="@drawable/btn_primary_pressed"
+        android:paddingVertical="15dp"
+        android:text="@string/find_id_button"
+        android:textSize="15sp"
+        android:textColor="@color/white"
+        app:layout_constraintTop_toBottomOf="@id/mcv_email"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_find_pw.xml
+++ b/app/src/main/res/layout/fragment_find_pw.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/tv_id_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="2dp"
+        android:layout_marginTop="35dp"
+        android:text="@string/find_pw_id_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_name"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_id_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:boxBackgroundColor="@android:color/white"
+            app:boxBackgroundMode="none"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:hint="@string/find_pw_id"
+                android:inputType="text"
+                android:paddingVertical="15dp" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/tv_email_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="2dp"
+        android:layout_marginTop="20dp"
+        android:text="@string/find_id_email_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_email"
+        app:layout_constraintTop_toBottomOf="@id/mcv_name" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_email"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_email_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_email"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:boxBackgroundColor="@android:color/white"
+            app:boxBackgroundMode="none"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etEmail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:hint="@string/find_id_email"
+                android:inputType="textEmailAddress"
+                android:paddingVertical="15dp" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_login"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="45dp"
+        android:layout_marginBottom="5dp"
+        android:background="@drawable/btn_primary_pressed"
+        android:paddingVertical="15dp"
+        android:text="@string/find_pw_button"
+        android:textColor="@color/white"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mcv_email" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/login_title"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:textColor="@color/black"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/login_subtitle"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+    <TextView
+        android:id="@+id/tv_id_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="35dp"
+        android:layout_marginStart="2dp"
+        android:text="@string/login_id_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_id"
+        app:layout_constraintTop_toBottomOf="@id/tv_subtitle" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_id"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_id_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:boxBackgroundColor="@android:color/white"
+            app:boxBackgroundMode="none"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etId"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:hint="@string/login_id"
+                android:inputType="text"
+                android:paddingVertical="15dp" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/tv_pw_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:layout_marginStart="2dp"
+        android:text="@string/login_pw_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_pw"
+        app:layout_constraintTop_toBottomOf="@id/mcv_id" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_pw"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_pw_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_pw"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:boxBackgroundColor="@android:color/white"
+            app:boxBackgroundMode="none"
+            app:endIconMode="password_toggle"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etPw"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:hint="@string/login_pw"
+                android:inputType="textPassword"
+                android:paddingVertical="15dp" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_login"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="45dp"
+        android:layout_marginHorizontal="32dp"
+        android:background="@drawable/btn_primary_pressed"
+        android:paddingVertical="15dp"
+        android:text="@string/login_button"
+        android:textSize="15sp"
+        android:textColor="@color/white"
+        app:layout_constraintTop_toBottomOf="@id/mcv_pw"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_to_signup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/login_to_join"
+        android:textSize="15sp"
+        android:layout_marginTop="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_login" />
+
+    <TextView
+        android:id="@+id/tv_to_find"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/login_to_find"
+        android:textSize="15sp"
+        android:layout_marginTop="5dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_to_signup" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_signup_agree.xml
+++ b/app/src/main/res/layout/fragment_signup_agree.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_signup_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/signup_title"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_signup_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/signup_agree_subtitle"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_signup_title" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_agree_all"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="40dp"
+        app:cardCornerRadius="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_signup_subtitle"
+        app:strokeColor="@color/auth_box_orange"
+        app:strokeWidth="1dp">
+
+        <CheckBox
+            android:id="@+id/cb_agree_all"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:buttonTint="@color/hover_orange"
+            android:paddingStart="8dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:text="@string/signup_agree_all"
+            android:textSize="16sp" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_agree_service"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="20dp"
+        app:cardCornerRadius="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mcv_agree_all"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <CheckBox
+            android:id="@+id/cb_agree_service"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:buttonTint="@color/text_secondary_gray"
+            android:paddingStart="8dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:text="@string/signup_agree_service"
+            android:textSize="16sp" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_agree_personal"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="16dp"
+        app:cardCornerRadius="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mcv_agree_service"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <CheckBox
+            android:id="@+id/cb_agree_personal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:buttonTint="@color/text_secondary_gray"
+            android:paddingStart="8dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:text="@string/signup_agree_personal"
+            android:textSize="16sp" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_agree_marketing"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="16dp"
+        app:cardCornerRadius="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mcv_agree_personal"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <CheckBox
+            android:id="@+id/cb_agree_marketing"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:buttonTint="@color/text_secondary_gray"
+            android:paddingStart="8dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:text="@string/signup_agree_marketing"
+            android:textSize="16sp" />
+    </com.google.android.material.card.MaterialCardView>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_next"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="35dp"
+        android:background="@drawable/btn_primary_pressed"
+        android:paddingVertical="15dp"
+        android:text="@string/signup_agree_button"
+        android:textColor="@color/white"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/mcv_agree_marketing" />
+
+    <TextView
+        android:id="@+id/tv_to_login_from_signup_agree"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="@string/signup_to_login"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_next" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_signup_info.xml
+++ b/app/src/main/res/layout/fragment_signup_info.xml
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tv_signup_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/signup_title"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:textColor="@color/black"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_signup_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/signup_info_subtitle"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_signup_title" />
+
+    <TextView
+        android:id="@+id/tv_signup_id_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="35dp"
+        android:layout_marginStart="2dp"
+        android:text="@string/signup_info_id_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_signup_id"
+        app:layout_constraintTop_toBottomOf="@id/tv_signup_subtitle" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_signup_id"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_signup_id_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/til_signup_id"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                app:boxBackgroundColor="@android:color/white"
+                app:boxBackgroundMode="none"
+                app:hintEnabled="false">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etSignupId"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:hint="@string/signup_info_id"
+                    android:inputType="text"
+                    android:paddingVertical="15dp" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_check_id"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginEnd="6dp"
+                android:backgroundTint="@color/auth_gray"
+                android:text="@string/signup_info_id_detail"
+                android:textColor="@color/white"
+                android:textSize="16sp"
+                android:elevation="0dp"/>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/tv_signup_pw_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginStart="2dp"
+        android:text="@string/signup_info_pw_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_signup_pw"
+        app:layout_constraintTop_toBottomOf="@id/mcv_signup_id" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_signup_pw"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_signup_pw_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_signup_pw"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:boxBackgroundColor="@android:color/white"
+            app:boxBackgroundMode="none"
+            app:endIconMode="password_toggle"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etSignupPw"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:hint="@string/signup_info_pw_check"
+                android:inputType="textPassword"
+                android:paddingVertical="15dp" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/tv_signup_pw_check_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="@string/signup_info_pw_check_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_signup_pw_check"
+        app:layout_constraintTop_toBottomOf="@id/mcv_signup_pw" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_signup_pw_check"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_signup_pw_check_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_signup_pw_check"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:boxBackgroundColor="@android:color/white"
+            app:boxBackgroundMode="none"
+            app:endIconMode="password_toggle"
+            app:hintEnabled="false">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etSignupPw_check"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:hint="@string/signup_info_pw_check"
+                android:inputType="textPassword"
+                android:paddingVertical="15dp" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/tv_signup_email_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginStart="2dp"
+        android:text="@string/signup_info_email_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_signup_email"
+        app:layout_constraintTop_toBottomOf="@id/mcv_signup_pw_check" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_signup_email"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_signup_email_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/til_signup_email"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                app:boxBackgroundColor="@android:color/white"
+                app:boxBackgroundMode="none"
+                app:hintEnabled="false">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etSignupEmail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:hint="@string/signup_info_email"
+                    android:inputType="textEmailAddress"
+                    android:paddingVertical="15dp" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_request_email_code"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginEnd="6dp"
+                android:backgroundTint="@color/auth_gray"
+                android:text="@string/signup_info_email_detail"
+                android:textColor="@color/white"
+                android:textSize="16sp"
+                android:elevation="0dp"/>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <TextView
+        android:id="@+id/tv_signup_code_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginStart="2dp"
+        android:text="@string/signup_info_code_title"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="@+id/mcv_signup_code"
+        app:layout_constraintTop_toBottomOf="@id/mcv_signup_email" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/mcv_signup_code"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="6dp"
+        app:cardCornerRadius="6dp"
+        app:cardElevation="6dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_signup_code_title"
+        app:strokeColor="@color/auth_box_gray"
+        app:strokeWidth="1dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/til_signup_code"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                app:boxBackgroundColor="@android:color/white"
+                app:boxBackgroundMode="none"
+                app:hintEnabled="false">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etSignupCode"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:hint="@string/signup_info_code"
+                    android:inputType="number"
+                    android:paddingVertical="15dp" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/btn_check_email_code"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
+                android:layout_marginEnd="6dp"
+                android:backgroundTint="@color/auth_gray"
+                android:text="@string/signup_info_code_detail"
+                android:textColor="@color/white"
+                android:textSize="16sp"
+                android:elevation="0dp"/>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_signup"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="35dp"
+        android:layout_marginHorizontal="32dp"
+        android:background="@drawable/btn_primary_pressed"
+        android:paddingVertical="15dp"
+        android:text="@string/signup_info_button"
+        android:textSize="15sp"
+        android:textColor="@color/white"
+        app:layout_constraintTop_toBottomOf="@id/mcv_signup_code"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_to_login"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/signup_to_login"
+        android:textSize="15sp"
+        android:layout_marginTop="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_signup" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/auth_nav_graph.xml
+++ b/app/src/main/res/navigation/auth_nav_graph.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/auth_nav_graph"
+    app:startDestination="@id/loginFragment">
+
+    <fragment
+        android:id="@+id/loginFragment"
+        android:name="com.hyosimroad.hamkkae.presentation.main.auth.login.LoginFragment"
+        android:label="로그인"
+        tools:layout="@layout/fragment_login">
+
+        <action
+            android:id="@+id/action_loginFragment_to_signupAgreeFragment"
+            app:destination="@id/signupAgreeFragment" />
+
+        <action
+            android:id="@+id/action_loginFragment_to_findFragment"
+            app:destination="@id/findFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/signupAgreeFragment"
+        android:name="com.hyosimroad.hamkkae.presentation.main.auth.signup.SignupAgreeFragment"
+        android:label="회원가입 약관 동의"
+        tools:layout="@layout/fragment_signup_agree" />
+
+    <action
+        android:id="@+id/action_signupAgreeFragment_to_signupInfoFragment"
+        app:destination="@id/signupInfoFragment" />
+
+    <action
+        android:id="@+id/action_signupAgreeFragment_to_loginFragment"
+        app:destination="@id/loginFragment" />
+
+    <fragment
+        android:id="@+id/signupInfoFragment"
+        android:name="com.hyosimroad.hamkkae.presentation.main.auth.signup.SignupInfoFragment"
+        android:label="회원가입 정보 입력"
+        tools:layout="@layout/fragment_signup_info">
+
+        <action
+            android:id="@+id/action_signupInfoFragment_to_loginFragment"
+            app:destination="@id/loginFragment" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/findFragment"
+        android:name="com.hyosimroad.hamkkae.presentation.main.auth.find.FindFragment"
+        android:label="계정 찾기"
+        tools:layout="@layout/fragment_find">
+
+        <action
+            android:id="@+id/action_findFragment_to_loginFragment"
+            app:destination="@id/loginFragment" />
+    </fragment>
+</navigation>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,6 +15,11 @@
     <color name="background_yellow">#FEFCE8</color>
     <color name="text_secondary_gray">#5F5F5F</color>
 
+    <!--auth-->
+    <color name="auth_box_gray">#DDDDDD</color>
+    <color name="auth_gray">#BFBFBF</color>
+    <color name="auth_box_orange">#FB923C</color>
+
     <!--state-->
     <color name="state_complete_gray">#E5E5E5</color>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,58 @@
 <resources>
     <string name="app_name">hamkkae</string>
 
+    <!--auth-->
+    <string name="login_title">함께가효</string>
+    <string name="login_subtitle">부모님과 함께하는 특별한 여행</string>
+    <string name="login_id_title">아이디</string>
+    <string name="login_id">아이디를 입력하세요</string>
+    <string name="login_pw_title">비밀번호</string>
+    <string name="login_pw">비밀번호를 입력하세요</string>
+    <string name="login_button">로그인</string>
+    <string name="login_to_join">계정이 없으신가요? 회원가입</string>
+    <string name="login_to_find">계정을 잊으셨나요? 아이디, 비밀번호 찾기</string>
+
+    <string name="signup_title">회원가입</string>
+    <string name="signup_agree_subtitle">서비스 이용을 위한 약관에 동의해주세요</string>
+    <string name="signup_agree_all">전체 동의하기</string>
+    <string name="signup_agree_service">[필수] 서비스 이용약관</string>
+    <string name="signup_agree_personal">[필수] 개인정보 처리방침</string>
+    <string name="signup_agree_marketing">[선택] 마케팅 정보 수신 동의</string>
+    <string name="signup_agree_button">다음 단계로</string>
+    <string name="signup_to_login">이미 계정이 있으신가요? 로그인</string>
+
+    <string name="signup_info_subtitle">서비스 이용을 위한 정보를 입력해주세요</string>
+    <string name="signup_info_id_title">아이디</string>
+    <string name="signup_info_id">아이디를 입력하세요</string>
+    <string name="signup_info_id_detail">확인</string>
+    <string name="signup_info_pw_title">비밀번호</string>
+    <string name="signup_info_pw">비밀번호를 입력하세요</string>
+    <string name="signup_info_pw_check_title">비밀번호 확인</string>
+    <string name="signup_info_pw_check">비밀번호를 입력하세요</string>
+    <string name="signup_info_email_title">이메일</string>
+    <string name="signup_info_email">이메일을 입력하세요</string>
+    <string name="signup_info_email_detail">인증 요청</string>
+    <string name="signup_info_code_title">코드</string>
+    <string name="signup_info_code">코드를 입력하세요</string>
+    <string name="signup_info_code_detail">확인</string>
+    <string name="signup_info_button">회원가입</string>
+
+    <string name="find_title">계정 찾기</string>
+    <string name="find_subtitle">계정을 찾기 위한 정보를 입력해주세요</string>
+    <string name="find_id_button">아이디 찾기</string>
+    <string name="find_pw_button">비밀번호 찾기</string>
+    <string name="find_to_login">계정이 기억나셨나요? 로그인</string>
+
+    <string name="find_id_name_title">이름</string>
+    <string name="find_id_name">이름을 입력해주세요</string>
+    <string name="find_id_email_title">이메일</string>
+    <string name="find_id_email">이메일을 입력해주세요</string>
+
+    <string name="find_pw_id_title">아이디</string>
+    <string name="find_pw_id">아이디를 입력해주세요</string>
+    <string name="find_pw_email_title">이메일</string>
+    <string name="find_pw_email">이메일을 입력해주세요</string>
+
     <!--state-->
     <string name="state_complete">완료</string>
     <string name="state_in_progress">진행중</string>
@@ -105,7 +157,7 @@
     <!--overview-->
     <string name="overview_preview">일정 미리보기</string>
     <string name="overview_first_day">첫째 날</string>
-    
+
     <!--info-->
     <string name="info_signature">대표 메뉴</string>
     <string name="info_amenities">편의시설</string>
@@ -113,7 +165,7 @@
     <string name="info_map">지도보기</string>
     <string name="info_checkin">체크인</string>
     <string name="info_checkout">체크아웃</string>
-    
+
     <!--tip-->
     <string name="tip_caution">동행 시 주의사항</string>
     <string name="tip_best_visit">최적 방문 시기</string>
@@ -207,7 +259,6 @@
 
     <!--answers-->
     <string name="answers_more">+ %d개 더</string>
-
 
     <!--                                  mock                                 -->
 


### PR DESCRIPTION
- 로그인, 회원가입(약관 동의, 정보 입력), 계정찾기(아이디 찾기, 비밀번호 찾기) 화면 구현
- 구조는 AuthActivity 안에 각각의 Fragment로 구현
- Auth Activity에 스크롤뷰 넣어서 길어지는 화면은 스크롤 가능
- model 패키지에 각각 화면에 대한 data class 있음
- 로그인: 로그인 버튼 클릭 시 홈화면으로 이동, 회원가입 버튼 클릭 시 회원가입으로 이동
- 회원가입: 로그인 버튼 클릭 시 로그인으로 이동(회원가입 프래그먼트 기록 삭제)
- 계정찾기: Tab 활용해서 아이디 또는 비밀번호 찾기로 전환, 로그인 버튼 클릭 시 로그인으로 이동(계정 찾기 프래그먼트 기록 삭제)

<img width="240" height="597" alt="Image" src="https://github.com/user-attachments/assets/74b8f914-cc88-41f7-b061-d3778b46156d" />
<img width="240" height="597" alt="Image" src="https://github.com/user-attachments/assets/a72a5568-fe0a-44d3-8f8c-649cf9c44770" />
<img width="240" height="597" alt="Image" src="https://github.com/user-attachments/assets/601eae3a-b13c-474c-abe1-0c16d0db9199" />
<img width="240" height="597" alt="Image" src="https://github.com/user-attachments/assets/129c0ac3-ecc3-4973-a06a-da10a6766cbe" />
<img width="240" height="597" alt="Image" src="https://github.com/user-attachments/assets/e036a903-c7ba-4bcd-914f-cd69362af856" />