### PR TITLE
feat: find-id #58

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".presentation.auth.find.FindActivity"
+            android:exported="false"/>
 
         <activity
             android:name=".presentation.main.home.MainActivity"

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/auth/find/FindActivity.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/auth/find/FindActivity.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
@@ -21,33 +22,31 @@ import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.tabs.TabLayout
 import com.hyosimroad.hamkkae.R
-import com.hyosimroad.hamkkae.databinding.FragmentFindBinding
+import com.hyosimroad.hamkkae.databinding.ActivityAuthBinding
+import com.hyosimroad.hamkkae.databinding.ActivityFindBinding
 import timber.log.Timber
 
-class FindFragment : Fragment() {
-    private var _binding: FragmentFindBinding? = null
-    private val binding: FragmentFindBinding
-        get() = requireNotNull(_binding) { "Find fragment is null" }
+class FindActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityFindBinding
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentFindBinding.inflate(inflater, container, false)
-        return binding.root
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        initBinds()
+        setting()
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        Timber.d("FingFragment started!")
+    private fun initBinds() {
+        binding = ActivityFindBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
 
+    private fun setting(){
         setupTab()
         applySpannableStyle(
             textView = binding.tvToLogin,
             fullTextResId = R.string.find_to_login,
             targetText = "로그인"
         )
-
-        clickLoginButton()
     }
 
     private fun setupTab() {
@@ -66,9 +65,9 @@ class FindFragment : Fragment() {
         binding.tabLayout.addTab(binding.tabLayout.newTab().setText(getString(R.string.find_pw_button)))
     }
 
-    private fun replaceFragment(fragment: Fragment) {
-        childFragmentManager.commit {
-            replace(R.id.fragment_container, fragment)
+    fun replaceFragment(fragment: Fragment) {
+        supportFragmentManager.commit {
+            replace(R.id.fcv_find, fragment)
             setReorderingAllowed(true)
         }
     }
@@ -84,7 +83,7 @@ class FindFragment : Fragment() {
 
         if (startIndex != -1) {
             val endIndex = startIndex + targetText.length
-            val color = ContextCompat.getColor(requireContext(), R.color.auth_box_orange)
+            val color = ContextCompat.getColor(this, R.color.auth_box_orange)
 
             val sizeInPx = TypedValue.applyDimension(
                 TypedValue.COMPLEX_UNIT_SP,
@@ -101,20 +100,7 @@ class FindFragment : Fragment() {
         textView.text = spannableString
     }
 
-    private fun clickLoginButton() {
-        binding.tvToLogin.setOnClickListener {
-            findNavController().navigate(
-                R.id.action_findFragment_to_loginFragment,
-                null,
-                NavOptions.Builder()
-                    .setPopUpTo(R.id.findFragment, true)
-                    .build()
-            )
-        }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        _binding = null
+    fun selectTab(index: Int) {
+        binding.tabLayout.getTabAt(index)?.select()
     }
 }

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/auth/find/FindIdFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/auth/find/FindIdFragment.kt
@@ -1,9 +1,12 @@
 package com.hyosimroad.hamkkae.presentation.auth.find
 
+import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.widget.ImageViewCompat
+import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.hyosimroad.hamkkae.R
@@ -25,7 +28,82 @@ class FindIdFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         Timber.d("FingFragment started!")
+        setting()
+    }
 
+    private fun setting(){
+        checkEmail()
+        checkCode()
+
+        binding.btnSend.setOnClickListener{
+            binding.clCode.visibility = View.VISIBLE
+            binding.btnSend.visibility = View.GONE
+        }
+
+        binding.btnVerifyCode.setOnClickListener {
+            (activity as? FindActivity)?.replaceFragment(FindIdResultFragment())
+        }
+    }
+
+    private fun checkEmail() {
+        with(binding) {
+            etEmail.addTextChangedListener {
+                if (isValidEmail(it.toString())) {
+                    tvAvailableEmail.visibility = View.GONE
+                    icEmail.visibility = View.INVISIBLE
+
+                    btnSend.isEnabled = true
+                    btnSend.backgroundTintList =
+                        ColorStateList.valueOf(requireContext().getColor(R.color.auth_box_orange))
+                } else {
+                    tvAvailableEmail.apply {
+                        visibility = View.VISIBLE
+                        text = getString(R.string.signup_info_email_rule)
+                        setTextColor(requireContext().getColor(R.color.auth_no_red))
+                    }
+
+                    icEmail.visibility = View.VISIBLE
+                    icEmail.setImageResource(R.drawable.ic_no_white_24)  // 아이콘 설정
+                    ImageViewCompat.setImageTintList(
+                        binding.icEmail,
+                        ColorStateList.valueOf(requireContext().getColor(R.color.auth_no_red))
+                    )
+
+                    btnSend.isEnabled = false
+                    btnSend.backgroundTintList =
+                        ColorStateList.valueOf(requireContext().getColor(R.color.auth_gray))
+                }
+            }
+        }
+    }
+
+    private fun isValidEmail(email: String): Boolean {
+        // 영문/숫자/._%+- 조합 + @ + 도메인 + 최종 .com/.net/.org 등
+        val regex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$".toRegex()
+        return email.matches(regex)
+    }
+
+    private fun checkCode(){
+        binding.etCode.addTextChangedListener{ text->
+            val input = text.toString()
+
+            // 6자리 숫자 패턴 검사
+            val isValid = input.matches(Regex("^\\d{6}$"))
+
+            if (isValid) {
+                binding.etCode.error = null
+                binding.btnVerifyCode.isEnabled = true
+                binding.btnVerifyCode.backgroundTintList =
+                    ColorStateList.valueOf(requireContext().getColor(R.color.auth_box_orange))
+            } else {
+                if (input.isNotEmpty()) {
+                    binding.etCode.error = "6자리 숫자를 입력하세요"
+                }
+                binding.btnVerifyCode.isEnabled = false
+                binding.btnVerifyCode.backgroundTintList =
+                    ColorStateList.valueOf(requireContext().getColor(R.color.auth_gray))
+            }
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/auth/find/FindIdResultFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/auth/find/FindIdResultFragment.kt
@@ -1,0 +1,45 @@
+package com.hyosimroad.hamkkae.presentation.auth.find
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.hyosimroad.hamkkae.databinding.FragmentFindIdResultBinding
+import com.hyosimroad.hamkkae.presentation.auth.AuthActivity
+import timber.log.Timber
+
+class FindIdResultFragment: Fragment() {
+    private var _binding: FragmentFindIdResultBinding? = null
+    private val binding: FragmentFindIdResultBinding
+        get() = requireNotNull(_binding) { "Find Result fragment is null" }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentFindIdResultBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Timber.d("FindResultFragment started!")
+        setting()
+    }
+
+    private fun setting(){
+        binding.btnLogin.setOnClickListener {
+            requireActivity().finish()
+        }
+
+        binding.btnFindPw.setOnClickListener {
+            (activity as? FindActivity)?.selectTab(1)
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/hyosimroad/hamkkae/presentation/auth/login/LoginFragment.kt
+++ b/app/src/main/java/com/hyosimroad/hamkkae/presentation/auth/login/LoginFragment.kt
@@ -23,6 +23,7 @@ import androidx.navigation.fragment.findNavController
 import com.hyosimroad.hamkkae.R
 import com.hyosimroad.hamkkae.databinding.FragmentLoginBinding
 import com.hyosimroad.hamkkae.extension.auth.LoginState
+import com.hyosimroad.hamkkae.presentation.auth.find.FindActivity
 import com.hyosimroad.hamkkae.presentation.main.home.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -133,7 +134,8 @@ class LoginFragment : Fragment() {
 
     private fun clickFindButton() {
         binding.tvToFind.setOnClickListener {
-            findNavController().navigate(R.id.action_loginFragment_to_findFragment)
+            val intent = Intent(requireContext(), FindActivity::class.java)
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/res/drawable/bg_white_stroke.xml
+++ b/app/src/main/res/drawable/bg_white_stroke.xml
@@ -4,4 +4,5 @@
     <corners android:radius="5dp"/>
     <stroke android:color="@color/state_complete_gray"
         android:width="1dp"/>
+    <padding android:left="0dp" android:top="0dp" android:right="0dp" android:bottom="0dp"/>
 </shape>

--- a/app/src/main/res/layout/activity_find.xml
+++ b/app/src/main/res/layout/activity_find.xml
@@ -3,28 +3,48 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/background_yellow">
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_back"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:background="@drawable/ic_back_black_24"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tv_title"
+        app:layout_constraintBottom_toBottomOf="@id/tv_subtitle"
+        app:layout_constraintWidth_percent="0.08" />
 
     <TextView
         android:id="@+id/tv_title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="20dp"
         android:text="@string/find_title"
         android:textColor="@color/black"
         android:textSize="18sp"
         android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/tv_subtitle"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/btn_back"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/tv_subtitle"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="20dp"
         android:text="@string/find_subtitle"
+        android:textColor="@color/text_secondary_gray"
         android:textSize="16sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/tv_title"
+        app:layout_constraintStart_toStartOf="@id/tv_title"
         app:layout_constraintTop_toBottomOf="@id/tv_title" />
 
     <FrameLayout
@@ -53,12 +73,13 @@
     </FrameLayout>
 
     <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragment_container"
+        android:id="@+id/fcv_find"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tabContainer" />
+        app:layout_constraintTop_toBottomOf="@id/tabContainer"
+        app:layout_constraintBottom_toTopOf="@id/tv_to_login"/>
 
     <TextView
         android:id="@+id/tv_to_login"
@@ -69,6 +90,6 @@
         android:textSize="15sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/fragment_container" />
+        app:layout_constraintTop_toBottomOf="@+id/fcv_find" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_find_id.xml
+++ b/app/src/main/res/layout/fragment_find_id.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -9,61 +8,171 @@
         android:id="@+id/tv_email_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="35dp"
         android:layout_marginStart="2dp"
+        android:layout_marginTop="35dp"
         android:text="@string/find_id_email_title"
         android:textSize="16sp"
-        app:layout_constraintStart_toStartOf="@+id/mcv_email"
+        app:layout_constraintStart_toStartOf="@+id/til_email"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/mcv_email"
-        android:layout_width="0dp"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_email"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="32dp"
         android:layout_marginTop="6dp"
-        app:cardCornerRadius="6dp"
-        app:cardElevation="6dp"
+        app:boxBackgroundColor="@android:color/white"
+        app:boxBackgroundMode="outline"
+        app:boxStrokeColor="@color/auth_box_gray"
+        app:boxStrokeWidth="1dp"
+        app:hintEnabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_email_title"
-        app:strokeColor="@color/auth_box_gray"
-        app:strokeWidth="1dp">
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.TextInputLayout.Rounded">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/til_email"
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etEmail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:hint="@string/find_id_email"
+            android:inputType="textEmailAddress"
+            android:paddingVertical="15dp" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <ImageView
+        android:id="@+id/ic_email"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="2dp"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintStart_toStartOf="@id/til_email"
+        app:layout_constraintTop_toBottomOf="@id/til_email"
+        app:layout_constraintWidth_percent="0.05" />
+
+    <TextView
+        android:id="@+id/tv_available_email"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="3dp"
+        app:layout_constraintBottom_toBottomOf="@id/ic_email"
+        app:layout_constraintEnd_toEndOf="@id/til_email"
+        app:layout_constraintStart_toEndOf="@id/ic_email"
+        app:layout_constraintTop_toTopOf="@id/ic_email" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_code"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        android:visibility="invisible"
+        app:layout_constraintTop_toBottomOf="@id/ic_email"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/tv_code_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="2dp"
+            android:text="@string/find_id_code"
+            android:textSize="16sp"
+            app:layout_constraintStart_toStartOf="@+id/til_code"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_code"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="32dp"
+            android:layout_marginTop="6dp"
             app:boxBackgroundColor="@android:color/white"
-            app:boxBackgroundMode="none"
-            app:hintEnabled="false">
+            app:boxBackgroundMode="outline"
+            app:boxStrokeColor="@color/auth_box_gray"
+            app:boxStrokeWidth="1dp"
+            app:hintEnabled="false"
+            app:shapeAppearanceOverlay="@style/ShapeAppearance.TextInputLayout.Rounded"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_code_title">
 
             <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/etEmail"
+                android:id="@+id/et_code"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
-                android:hint="@string/find_id_email"
-                android:inputType="textEmailAddress"
+                android:hint="@string/find_id_input_code"
+                android:inputType="number"
                 android:paddingVertical="15dp" />
         </com.google.android.material.textfield.TextInputLayout>
-    </com.google.android.material.card.MaterialCardView>
+
+        <ImageView
+            android:id="@+id/ic_code"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="2dp"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintStart_toStartOf="@id/til_code"
+            app:layout_constraintTop_toBottomOf="@id/til_code"
+            app:layout_constraintWidth_percent="0.05" />
+
+        <TextView
+            android:id="@+id/tv_available_code"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="3dp"
+            app:layout_constraintBottom_toBottomOf="@id/ic_code"
+            app:layout_constraintEnd_toEndOf="@id/til_code"
+            app:layout_constraintStart_toEndOf="@id/ic_code"
+            app:layout_constraintTop_toTopOf="@id/ic_code" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_verify_code"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="3dp"
+            android:layout_marginTop="10dp"
+            android:backgroundTint="@color/auth_gray"
+            android:text="@string/find_id_verify"
+            android:textColor="@color/white"
+            app:layout_constraintTop_toBottomOf="@id/ic_code"
+            app:layout_constraintStart_toStartOf="@id/ic_code"
+            app:layout_constraintEnd_toStartOf="@id/btn_resend"
+            app:layout_constraintHorizontal_weight="2"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_resend"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="3dp"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:backgroundTint="@color/white"
+            android:text="@string/find_id_resend"
+            android:textColor="@color/text_secondary_gray"
+            app:strokeColor="@color/auth_gray"
+            app:strokeWidth="2dp"
+            app:layout_constraintTop_toTopOf="@id/btn_verify_code"
+            app:layout_constraintBottom_toBottomOf="@id/btn_verify_code"
+            app:layout_constraintStart_toEndOf="@id/btn_verify_code"
+            app:layout_constraintEnd_toEndOf="@id/til_code"
+            app:layout_constraintHorizontal_weight="1"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/btn_login"
+        android:id="@+id/btn_send"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="45dp"
-        android:layout_marginBottom="5dp"
         android:layout_marginHorizontal="32dp"
-        android:background="@drawable/btn_primary_pressed"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="5dp"
+        android:backgroundTint="@color/auth_gray"
         android:paddingVertical="15dp"
-        android:text="@string/find_id_button"
-        android:textSize="15sp"
+        android:text="@string/find_id_send"
         android:textColor="@color/white"
-        app:layout_constraintTop_toBottomOf="@id/mcv_email"
-        app:layout_constraintStart_toStartOf="parent"
+        android:textSize="15sp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ic_email" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_find_id_result.xml
+++ b/app/src/main/res/layout/fragment_find_id_result.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_yellow"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <LinearLayout
+        android:id="@+id/ll_show"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="20dp"
+        android:background="@drawable/bg_white_stroke"
+        android:orientation="vertical"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/tv_find"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/find_id_show"
+            android:layout_marginTop="20dp"/>
+
+        <TextView
+            android:id="@+id/tv_user_id"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="testuser"
+            android:textStyle="bold"
+            android:textSize="22sp"
+            android:layout_marginTop="6dp"/>
+
+        <TextView
+            android:id="@+id/tv_can_login"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/find_id_can_login"
+            android:gravity="center"
+            android:layout_marginTop="5dp"
+            android:layout_marginBottom="20dp"/>
+
+    </LinearLayout>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_login"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="45dp"
+        android:layout_marginBottom="5dp"
+        android:background="@drawable/btn_primary_pressed"
+        android:paddingVertical="15dp"
+        android:text="@string/find_id_go_login"
+        android:textColor="@color/white"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ll_show" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_find_pw"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="32dp"
+        android:layout_marginTop="10dp"
+        android:background="@drawable/bg_white_stroke"
+        android:paddingVertical="15dp"
+        android:text="@string/find_pw_button"
+        android:textColor="@color/text_secondary_gray"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btn_login" />
+
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/auth_nav_graph.xml
+++ b/app/src/main/res/navigation/auth_nav_graph.xml
@@ -14,10 +14,6 @@
         <action
             android:id="@+id/action_loginFragment_to_signupAgreeFragment"
             app:destination="@id/signupAgreeFragment" />
-
-        <action
-            android:id="@+id/action_loginFragment_to_findFragment"
-            app:destination="@id/findFragment" />
     </fragment>
 
     <fragment
@@ -42,17 +38,6 @@
 
         <action
             android:id="@+id/action_signupInfoFragment_to_loginFragment"
-            app:destination="@id/loginFragment" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/findFragment"
-        android:name="com.hyosimroad.hamkkae.presentation.auth.find.FindFragment"
-        android:label="계정 찾기"
-        tools:layout="@layout/fragment_find">
-
-        <action
-            android:id="@+id/action_findFragment_to_loginFragment"
             app:destination="@id/loginFragment" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,15 @@
     <string name="find_title">계정 찾기</string>
     <string name="find_subtitle">계정을 찾기 위한 정보를 입력해주세요</string>
     <string name="find_id_button">아이디 찾기</string>
+    <string name="find_id_send">인증번호 발송</string>
+    <string name="find_id_code">인증번호</string>
+    <string name="find_id_input_code">6자리 인증번호를 입력하세요</string>
+    <string name="find_id_verify">인증 확인</string>
+    <string name="find_id_resend">다시 발송</string>
+    <string name="find_id_show">아이디를 찾았습니다</string>
+    <string name="find_id_can_login">위 아이디로 로그인하실 수 있습니다.</string>
+    <string name="find_id_go_login">로그인하러 가기</string>
+
     <string name="find_pw_button">비밀번호 찾기</string>
     <string name="find_to_login">계정이 기억나셨나요? 로그인</string>
 


### PR DESCRIPTION
[아이디 찾기 화면 구현]
- 계정 찾기 화면을 fragment -> activity로 변경
- 아이디 찾기에 이메일 입력 칸 추가
- 인증번호 발송 후 인증번호 입력하는 칸 추가
  - 조건에 부합할 시 번호 인증 가능
- 인증 후 사용자 아이디 보여주는 화면 추가
- 로그인하러 가기 버튼 클릭 시 첫 화면이 보여짐
- 비밀번호 찾기 버튼 클릭 시 비밀번호 찾기 화면 보여짐


https://github.com/user-attachments/assets/45dc4c9d-3118-45d1-82db-69a3cdf5c3c2

